### PR TITLE
feat: cursor-based pagination and saved filter support

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -144,6 +144,12 @@ func ProxySearch(c *jira.Client, jql string, from, limit uint) (*jira.SearchResu
 	return issues, err
 }
 
+// ProxySearchAll fetches all pages of search results using cursor-based pagination (v3).
+// Use this when --paginate all is specified.
+func ProxySearchAll(c *jira.Client, jql string, limit uint) (*jira.SearchResult, error) {
+	return c.SearchAll(jql, limit)
+}
+
 // ProxyAssignIssue uses either a v2 or v3 version of the PUT /issue/{key}/assignee
 // endpoint to assign an issue to the user.
 // Defaults to v3 if installation type is not defined in the config.

--- a/internal/cmd/issue/list/list.go
+++ b/internal/cmd/issue/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -37,6 +38,18 @@ $ jira issue list --paginate 20
 
 # Get 50 items starting from 10
 $ jira issue list --paginate 10:50
+
+# Fetch ALL issues (auto-paginate through all pages)
+$ jira issue list --paginate all
+
+# Use a saved Jira filter by ID
+$ jira issue list --filter 12345
+
+# Use a saved Jira filter by name
+$ jira issue list --filter "My Open Bugs"
+
+# Use a saved Jira filter and fetch all results
+$ jira issue list --filter 12345 --paginate all
 
 # Search for issues containing specific text
 $ jira issue list "Feature Request"
@@ -109,6 +122,27 @@ func loadList(cmd *cobra.Command, args []string) {
 		cmdutil.ExitIfError(cmd.Flags().Set("jql", searchQuery))
 	}
 
+	// Resolve filter name to ID if --filter is not numeric.
+	filterVal, _ := cmd.Flags().GetString("filter")
+	if filterVal != "" {
+		if _, numErr := strconv.Atoi(filterVal); numErr != nil {
+			client := api.DefaultClient(debug)
+			result, searchErr := client.FilterSearch(filterVal)
+			if searchErr != nil {
+				cmdutil.ExitIfError(fmt.Errorf("failed to search for filter %q: %w", filterVal, searchErr))
+			}
+			if len(result.Filters) == 0 {
+				cmdutil.Failed("No filter found with name %q", filterVal)
+				return
+			}
+			if len(result.Filters) > 1 {
+				fmt.Printf("Multiple filters found for %q, using first match: %s (ID: %s)\n",
+					filterVal, result.Filters[0].Name, result.Filters[0].ID)
+			}
+			cmdutil.ExitIfError(cmd.Flags().Set("filter", result.Filters[0].ID))
+		}
+	}
+
 	issues, err := func() ([]*jira.Issue, error) {
 		s := cmdutil.Info("Fetching issues...")
 		defer s.Stop()
@@ -118,7 +152,14 @@ func loadList(cmd *cobra.Command, args []string) {
 			return nil, err
 		}
 
-		resp, err := api.ProxySearch(api.DefaultClient(debug), q.Get(), q.Params().From, q.Params().Limit)
+		client := api.DefaultClient(debug)
+
+		var resp *jira.SearchResult
+		if q.Params().All {
+			resp, err = api.ProxySearchAll(client, q.Get(), q.Params().Limit)
+		} else {
+			resp, err = api.ProxySearch(client, q.Get(), q.Params().From, q.Params().Limit)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -236,9 +277,10 @@ func SetFlags(cmd *cobra.Command) {
 	cmd.Flags().String("created-before", "", "Filter by issues created before certain date")
 	cmd.Flags().String("updated-before", "", "Filter by issues updated before certain date")
 	cmd.Flags().StringP("jql", "q", "", "Run a raw JQL query in a given project context")
+	cmd.Flags().StringP("filter", "f", "", "Use a saved Jira filter by ID or name (e.g., --filter 12345 or --filter \"My Filter\")")
 	cmd.Flags().String("order-by", "created", "Field to order the list with")
 	cmd.Flags().Bool("reverse", false, "Reverse the display order (default \"DESC\")")
-	cmd.Flags().String("paginate", "0:100", "Paginate the result. Max 100 at a time, format: <from>:<limit> where <from> is optional")
+	cmd.Flags().String("paginate", "0:100", "Paginate the result. Use \"all\" to fetch all pages, or format: <from>:<limit> where <from> is optional")
 	cmd.Flags().Bool("plain", false, "Display output in plain mode")
 	cmd.Flags().Bool("no-headers", false, "Don't display table headers in plain mode. Works only with --plain")
 	cmd.Flags().Bool("no-truncate", false, "Show all available columns in plain mode. Works only with --plain")

--- a/internal/query/issue.go
+++ b/internal/query/issue.go
@@ -47,6 +47,15 @@ func splitPositiveNegative(labels []string) ([]string, []string) {
 
 // Get returns constructed jql query.
 func (i *Issue) Get() string {
+	// If a saved filter ID is specified, use it directly as the JQL.
+	if i.params.FilterID != "" {
+		jqlStr := fmt.Sprintf("filter = %s", i.params.FilterID)
+		if i.params.debug {
+			fmt.Printf("JQL: %s\n", jqlStr)
+		}
+		return jqlStr
+	}
+
 	var q *jql.JQL
 
 	defer func() {
@@ -188,7 +197,9 @@ type IssueParams struct {
 	Reverse       bool
 	From          uint
 	Limit         uint
+	All           bool
 	JQL           string
+	FilterID      string
 
 	debug bool
 }
@@ -231,9 +242,14 @@ func (ip *IssueParams) init(flags FlagParser) error {
 	if err != nil {
 		return err
 	}
-	from, limit, err := getPaginateParams(paginate)
+	from, limit, all, err := getPaginateParams(paginate)
 	if err != nil {
 		return err
+	}
+
+	filterID, err := flags.GetString("filter")
+	if err != nil {
+		filterID = ""
 	}
 
 	ip.setBoolParams(boolParamsMap)
@@ -242,6 +258,8 @@ func (ip *IssueParams) init(flags FlagParser) error {
 	ip.Status = status
 	ip.From = from
 	ip.Limit = limit
+	ip.All = all
+	ip.FilterID = filterID
 
 	return nil
 }
@@ -318,13 +336,13 @@ func addDay(dt time.Time, format string) string {
 	return dt.AddDate(0, 0, 1).Format(format)
 }
 
-func getPaginateParams(paginate string) (uint, uint, error) {
+func getPaginateParams(paginate string) (uint, uint, bool, error) {
 	var (
 		err         error
 		from, limit int
 
 		errInvalidPaginateArg = fmt.Errorf(
-			"invalid argument for paginate: must be a positive integer in format <from>:<limit>, where <from> is optional",
+			"invalid argument for paginate: must be \"all\" or a positive integer in format <from>:<limit>, where <from> is optional",
 		)
 		errOutOfBounds = fmt.Errorf(
 			"invalid argument for paginate: Format <from>:<limit>, where <from> is optional and "+
@@ -335,37 +353,41 @@ func getPaginateParams(paginate string) (uint, uint, error) {
 	paginate = strings.TrimSpace(paginate)
 
 	if paginate == "" {
-		return 0, defaultLimit, nil
+		return 0, defaultLimit, false, nil
+	}
+
+	if strings.EqualFold(paginate, "all") {
+		return 0, defaultLimit, true, nil
 	}
 
 	if !strings.Contains(paginate, ":") {
 		limit, err = strconv.Atoi(paginate)
 		if err != nil {
-			return 0, 0, errInvalidPaginateArg
+			return 0, 0, false, errInvalidPaginateArg
 		}
 	} else {
 		pieces := strings.Split(paginate, ":")
 		if len(pieces) != 2 {
-			return 0, 0, errInvalidPaginateArg
+			return 0, 0, false, errInvalidPaginateArg
 		}
 
 		from, err = strconv.Atoi(pieces[0])
 		if err != nil {
-			return 0, 0, errInvalidPaginateArg
+			return 0, 0, false, errInvalidPaginateArg
 		}
 
 		limit, err = strconv.Atoi(pieces[1])
 		if err != nil {
-			return 0, 0, errInvalidPaginateArg
+			return 0, 0, false, errInvalidPaginateArg
 		}
 	}
 
 	if from < 0 || limit <= 0 {
-		return 0, 0, errOutOfBounds
+		return 0, 0, false, errOutOfBounds
 	}
 	if limit > defaultLimit {
-		return 0, 0, errOutOfBounds
+		return 0, 0, false, errOutOfBounds
 	}
 
-	return uint(from), uint(limit), nil
+	return uint(from), uint(limit), false, nil
 }

--- a/internal/query/issue_test.go
+++ b/internal/query/issue_test.go
@@ -104,6 +104,9 @@ func (tfp *issueFlagParser) GetString(name string) (string, error) {
 	if name == "paginate" {
 		return "", nil
 	}
+	if name == "filter" {
+		return "", nil
+	}
 	return "test", nil
 }
 

--- a/internal/query/sprint.go
+++ b/internal/query/sprint.go
@@ -100,7 +100,7 @@ func (sp *SprintParams) init(flags FlagParser) error {
 	if err != nil {
 		return err
 	}
-	from, limit, err := getPaginateParams(paginate)
+	from, limit, _, err := getPaginateParams(paginate)
 	if err != nil {
 		return err
 	}

--- a/pkg/jira/search.go
+++ b/pkg/jira/search.go
@@ -16,15 +16,83 @@ type SearchResult struct {
 }
 
 // Search searches for issues using v3 version of the Jira GET /search endpoint.
+// Returns a single page of results.
 func (c *Client) Search(jql string, limit uint) (*SearchResult, error) {
 	path := fmt.Sprintf("/search/jql?jql=%s&maxResults=%d&fields=*all", url.QueryEscape(jql), limit)
 	return c.search(path, apiVersion3)
+}
+
+// SearchAll searches for issues using v3 version of the Jira GET /search endpoint,
+// automatically paginating through all pages using cursor-based pagination (nextPageToken).
+func (c *Client) SearchAll(jql string, limit uint) (*SearchResult, error) {
+	var allIssues []*Issue
+
+	pageToken := ""
+	for {
+		path := fmt.Sprintf("/search/jql?jql=%s&maxResults=%d&fields=*all", url.QueryEscape(jql), limit)
+		if pageToken != "" {
+			path += fmt.Sprintf("&nextPageToken=%s", url.QueryEscape(pageToken))
+		}
+
+		result, err := c.search(path, apiVersion3)
+		if err != nil {
+			return nil, err
+		}
+
+		allIssues = append(allIssues, result.Issues...)
+
+		if result.IsLast || result.NextPageToken == "" {
+			break
+		}
+		pageToken = result.NextPageToken
+	}
+
+	return &SearchResult{
+		IsLast: true,
+		Issues: allIssues,
+	}, nil
 }
 
 // SearchV2 searches an issues using v2 version of the Jira GET /search endpoint.
 func (c *Client) SearchV2(jql string, from, limit uint) (*SearchResult, error) {
 	path := fmt.Sprintf("/search?jql=%s&startAt=%d&maxResults=%d", url.QueryEscape(jql), from, limit)
 	return c.search(path, apiVersion2)
+}
+
+// Filter holds saved Jira filter info.
+type Filter struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	JQL  string `json:"jql"`
+}
+
+// FilterSearchResult holds response from /filter/search endpoint.
+type FilterSearchResult struct {
+	Total   int       `json:"total"`
+	IsLast  bool      `json:"isLast"`
+	Filters []*Filter `json:"values"`
+}
+
+// FilterSearch searches for saved Jira filters by name using GET /rest/api/3/filter/search.
+func (c *Client) FilterSearch(name string) (*FilterSearchResult, error) {
+	path := fmt.Sprintf("/filter/search?filterName=%s&expand=jql&maxResults=50", url.QueryEscape(name))
+
+	res, err := c.Get(context.Background(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out FilterSearchResult
+	err = json.NewDecoder(res.Body).Decode(&out)
+	return &out, err
 }
 
 func (c *Client) search(path, ver string) (*SearchResult, error) {


### PR DESCRIPTION
## Summary

- **Cursor-based pagination (`--paginate all`)**: Jira's new `/rest/api/3/search/jql` endpoint uses `nextPageToken` instead of `startAt`. Added `SearchAll()` that loops through all pages automatically.
- **Saved filter support (`--filter`)**: Accepts a filter ID (`--filter 30653`) or name (`--filter "My Open Bugs"`). Names are resolved to IDs via `/rest/api/3/filter/search`.
- **Filter name resolution**: `FilterSearch()` client method queries the Jira filter search API.

Fixes #1
Fixes #2

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Manual test: `jira issue list --paginate all`
- [ ] Manual test: `jira issue list --filter <ID>`
- [ ] Manual test: `jira issue list --filter "Filter Name"`
- [ ] Manual test: `jira issue list --filter <ID> --paginate all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)