### PR TITLE
feat: checklist command and JQL ORDER BY fix

### DIFF
--- a/internal/cmd/checklist/checklist.go
+++ b/internal/cmd/checklist/checklist.go
@@ -1,0 +1,253 @@
+package checklist
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+const (
+	helpText = `Manage checklists on Jira issues.
+
+Requires the "Checklist for Jira" plugin and the checklist custom field ID
+to be configured in your .jira config file:
+
+  checklist:
+    field: customfield_10693
+
+The field ID varies per Jira instance.`
+
+	examples = `# List checklist items
+$ jira checklist list ISSUE-123
+
+# Add an item to the checklist
+$ jira checklist add ISSUE-123 "Review the PR"
+
+# Mark item #1 as done (1-based index)
+$ jira checklist check ISSUE-123 1
+
+# Mark item #2 as open
+$ jira checklist uncheck ISSUE-123 2
+
+# Remove item #3
+$ jira checklist remove ISSUE-123 3`
+)
+
+// NewCmdChecklist is the checklist command.
+func NewCmdChecklist() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "checklist <subcommand>",
+		Short:   "Manage checklists on Jira issues",
+		Long:    helpText,
+		Example: examples,
+		Aliases: []string{"cl"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(
+		newCmdList(),
+		newCmdAdd(),
+		newCmdCheck(),
+		newCmdUncheck(),
+		newCmdRemove(),
+	)
+
+	return cmd
+}
+
+func getChecklistField() string {
+	field := viper.GetString("checklist.field")
+	if field == "" {
+		cmdutil.Failed("Checklist custom field is not configured.\n" +
+			"Add the following to your .jira config file:\n\n" +
+			"  checklist:\n" +
+			"    field: customfield_XXXXX\n")
+	}
+	return field
+}
+
+func getIssueKey(args []string) string {
+	project := viper.GetString("project.key")
+	return cmdutil.GetJiraIssueKey(project, args[0])
+}
+
+// --- list ---
+
+func newCmdList() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list ISSUE-KEY",
+		Short:   "List checklist items",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(1),
+		Run:     listChecklist,
+	}
+}
+
+func listChecklist(cmd *cobra.Command, args []string) {
+	field := getChecklistField()
+	key := getIssueKey(args)
+
+	debug, _ := cmd.Flags().GetBool("debug")
+	client := api.DefaultClient(debug)
+
+	items, err := client.GetChecklist(key, field)
+	cmdutil.ExitIfError(err)
+
+	if len(items) == 0 {
+		fmt.Println("No checklist items found.")
+		return
+	}
+
+	for i, item := range items {
+		marker := "[ ]"
+		if item.Status == "done" {
+			marker = "[x]"
+		}
+		fmt.Printf("  %d. %s %s\n", i+1, marker, item.Text)
+	}
+}
+
+// --- add ---
+
+func newCmdAdd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add ISSUE-KEY \"item text\"",
+		Short: "Add an item to the checklist",
+		Args:  cobra.ExactArgs(2),
+		Run:   addChecklistItem,
+	}
+}
+
+func addChecklistItem(cmd *cobra.Command, args []string) {
+	field := getChecklistField()
+	key := getIssueKey(args)
+	text := args[1]
+
+	debug, _ := cmd.Flags().GetBool("debug")
+	client := api.DefaultClient(debug)
+
+	items, err := client.GetChecklist(key, field)
+	cmdutil.ExitIfError(err)
+
+	items = append(items, jira.ChecklistItem{Text: text, Status: "open"})
+
+	err = client.SetChecklist(key, field, items)
+	cmdutil.ExitIfError(err)
+
+	cmdutil.Success("Item added to checklist on %s", key)
+}
+
+// --- check ---
+
+func newCmdCheck() *cobra.Command {
+	return &cobra.Command{
+		Use:   "check ISSUE-KEY INDEX",
+		Short: "Mark a checklist item as done",
+		Args:  cobra.ExactArgs(2),
+		Run:   checkItem,
+	}
+}
+
+func checkItem(cmd *cobra.Command, args []string) {
+	setItemStatus(cmd, args, "done")
+}
+
+// --- uncheck ---
+
+func newCmdUncheck() *cobra.Command {
+	return &cobra.Command{
+		Use:   "uncheck ISSUE-KEY INDEX",
+		Short: "Mark a checklist item as open",
+		Args:  cobra.ExactArgs(2),
+		Run:   uncheckItem,
+	}
+}
+
+func uncheckItem(cmd *cobra.Command, args []string) {
+	setItemStatus(cmd, args, "open")
+}
+
+func setItemStatus(cmd *cobra.Command, args []string, status string) {
+	field := getChecklistField()
+	key := getIssueKey(args)
+
+	idx, err := strconv.Atoi(args[1])
+	if err != nil || idx < 1 {
+		cmdutil.Failed("INDEX must be a positive integer (1-based)")
+		return
+	}
+
+	debug, _ := cmd.Flags().GetBool("debug")
+	client := api.DefaultClient(debug)
+
+	items, err := client.GetChecklist(key, field)
+	cmdutil.ExitIfError(err)
+
+	if idx > len(items) {
+		cmdutil.Failed("Index %d out of range. Checklist has %d items.", idx, len(items))
+		return
+	}
+
+	items[idx-1].Status = status
+
+	err = client.SetChecklist(key, field, items)
+	cmdutil.ExitIfError(err)
+
+	action := "checked"
+	if status == "open" {
+		action = "unchecked"
+	}
+	cmdutil.Success("Item %d %s on %s: %s", idx, action, key, items[idx-1].Text)
+}
+
+// --- remove ---
+
+func newCmdRemove() *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove ISSUE-KEY INDEX",
+		Short:   "Remove a checklist item",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(2),
+		Run:     removeItem,
+	}
+}
+
+func removeItem(cmd *cobra.Command, args []string) {
+	field := getChecklistField()
+	key := getIssueKey(args)
+
+	idx, err := strconv.Atoi(args[1])
+	if err != nil || idx < 1 {
+		cmdutil.Failed("INDEX must be a positive integer (1-based)")
+		return
+	}
+
+	debug, _ := cmd.Flags().GetBool("debug")
+	client := api.DefaultClient(debug)
+
+	items, err := client.GetChecklist(key, field)
+	cmdutil.ExitIfError(err)
+
+	if idx > len(items) {
+		cmdutil.Failed("Index %d out of range. Checklist has %d items.", idx, len(items))
+		return
+	}
+
+	removed := items[idx-1]
+	items = append(items[:idx-1], items[idx:]...)
+
+	err = client.SetChecklist(key, field, items)
+	cmdutil.ExitIfError(err)
+
+	_ = strings.TrimSpace(removed.Text)
+	cmdutil.Success("Removed item %d from %s: %s", idx, key, removed.Text)
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/board"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/checklist"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/completion"
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/epic"
 	initCmd "github.com/ankitpokhrel/jira-cli/internal/cmd/init"
@@ -131,6 +132,7 @@ func addChildCommands(cmd *cobra.Command) {
 		issue.NewCmdIssue(),
 		epic.NewCmdEpic(),
 		sprint.NewCmdSprint(),
+		checklist.NewCmdChecklist(),
 		board.NewCmdBoard(),
 		project.NewCmdProject(),
 		open.NewCmdOpen(),

--- a/pkg/jira/checklist.go
+++ b/pkg/jira/checklist.go
@@ -1,0 +1,182 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ChecklistItem represents a single checklist item.
+type ChecklistItem struct {
+	Text   string
+	Status string // "open" or "done"
+}
+
+// GetChecklist retrieves checklist items from the specified custom field on an issue.
+func (c *Client) GetChecklist(key, customField string) ([]ChecklistItem, error) {
+	path := fmt.Sprintf("/issue/%s?fields=%s", key, customField)
+
+	res, err := c.Get(context.Background(), path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var raw struct {
+		Fields map[string]json.RawMessage `json:"fields"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+
+	fieldData, ok := raw.Fields[customField]
+	if !ok || string(fieldData) == "null" {
+		return nil, nil
+	}
+
+	return parseChecklistADF(fieldData)
+}
+
+// SetChecklist writes checklist items to the specified custom field on an issue.
+func (c *Client) SetChecklist(key, customField string, items []ChecklistItem) error {
+	adf := buildChecklistADF(items)
+
+	payload := map[string]interface{}{
+		"fields": map[string]interface{}{
+			customField: adf,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	res, err := c.Put(context.Background(), "/issue/"+key, body, Header{
+		"Accept":       "application/json",
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusNoContent {
+		return formatUnexpectedResponse(res)
+	}
+	return nil
+}
+
+// parseChecklistADF parses the ADF document format used by the Checklist plugin.
+func parseChecklistADF(data json.RawMessage) ([]ChecklistItem, error) {
+	var doc struct {
+		Content []struct {
+			Type    string `json:"type"`
+			Content []struct {
+				Content []struct {
+					Content []struct {
+						Text string `json:"text"`
+					} `json:"content"`
+				} `json:"content"`
+			} `json:"content"`
+		} `json:"content"`
+	}
+
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("failed to parse checklist ADF: %w", err)
+	}
+
+	var items []ChecklistItem
+	for _, block := range doc.Content {
+		if block.Type != "bulletList" {
+			continue
+		}
+		for _, listItem := range block.Content {
+			for _, para := range listItem.Content {
+				for _, text := range para.Content {
+					item := parseChecklistItemText(text.Text)
+					items = append(items, item)
+				}
+			}
+		}
+	}
+
+	return items, nil
+}
+
+// parseChecklistItemText parses "[open] text" or "[done] text" format.
+func parseChecklistItemText(text string) ChecklistItem {
+	if len(text) > 7 && text[:6] == "[open]" {
+		return ChecklistItem{Text: text[7:], Status: "open"}
+	}
+	if len(text) > 7 && text[:6] == "[done]" {
+		return ChecklistItem{Text: text[7:], Status: "done"}
+	}
+	return ChecklistItem{Text: text, Status: "open"}
+}
+
+// buildChecklistADF constructs an ADF document for the checklist.
+func buildChecklistADF(items []ChecklistItem) map[string]interface{} {
+	listItems := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		prefix := fmt.Sprintf("[%s] ", item.Status)
+		listItems = append(listItems, map[string]interface{}{
+			"type": "listItem",
+			"content": []map[string]interface{}{
+				{
+					"type": "paragraph",
+					"content": []map[string]interface{}{
+						{
+							"type": "text",
+							"text": prefix + item.Text,
+						},
+					},
+				},
+			},
+		})
+	}
+
+	return map[string]interface{}{
+		"type":    "doc",
+		"version": 1,
+		"content": []map[string]interface{}{
+			{
+				"type": "orderedList",
+				"attrs": map[string]interface{}{
+					"order": 1,
+				},
+				"content": []map[string]interface{}{
+					{
+						"type": "listItem",
+						"content": []map[string]interface{}{
+							{
+								"type": "paragraph",
+								"content": []map[string]interface{}{
+									{
+										"type": "text",
+										"text": "Default checklist",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				"type":    "bulletList",
+				"content": listItems,
+			},
+		},
+	}
+}

--- a/pkg/jql/jql.go
+++ b/pkg/jql/jql.go
@@ -186,7 +186,15 @@ func (j *JQL) Raw(q string) *JQL {
 	if hasProjectFilter(q) {
 		j.filters = j.filters[1:]
 	}
-	j.filters = append(j.filters, q)
+	// If the raw JQL contains ORDER BY, extract it and use it
+	// instead of the default to avoid duplicate ORDER BY clauses.
+	if parts, orderBy, ok := extractOrderBy(q); ok {
+		q = strings.TrimSpace(parts)
+		j.orderBy = orderBy
+	}
+	if q != "" {
+		j.filters = append(j.filters, q)
+	}
 	return j
 }
 
@@ -229,4 +237,14 @@ func hasProjectFilter(str string) bool {
 	regx := "(?i)((project)[\\s]*?={0,1}\\b)[^'.']"
 	m, _ := regexp.MatchString(regx, str)
 	return m
+}
+
+// extractOrderBy splits a JQL string into the filter part and the ORDER BY clause.
+func extractOrderBy(q string) (string, string, bool) {
+	re := regexp.MustCompile(`(?i)\s+ORDER\s+BY\s+`)
+	loc := re.FindStringIndex(q)
+	if loc == nil {
+		return q, "", false
+	}
+	return q[:loc[0]], strings.TrimSpace(q[loc[0]:]), true
 }


### PR DESCRIPTION
## Summary

- **Checklist command** (`jira checklist` / `jira cl`): list, add, check, uncheck, remove items on issues via configurable custom field (Checklist for Jira plugin)
- **JQL fix**: `-q` with `ORDER BY` no longer duplicates the clause

Fixes #4
Fixes #5

## Test plan

- [x] All existing tests pass
- [x] Manual: checklist list, add, check verified against live Jira instance
- [x] Manual: `-q` with `ORDER BY` no longer produces duplicate clause